### PR TITLE
rewrite with go-arg and support service metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 ## Description
 
-Checks Mackerel host metrics are still being posted.
+Checks Mackerel host metrics (or service metrics) are still being posted.
 
 It is also available in the host metric of cloud integrations.
 
 ## Synopsis
 ```
 check-mackerel-metric -H HOST_ID -n METRIC_NAME -w WARNING_MINUTE -c CRITICAL_MINUTE
+check-mackerel-metric -s SERVICE_NAME -n METRIC_NAME -w WARNING_MINUTE -c CRITICAL_MINUTE
 ```
 
 CRITICAL (or WARNING) alert is issued if no metric has been posted since the minute specified for CRITICAL_MINUTE (or WARNING_MINUTE) from the current time.
@@ -17,31 +18,36 @@ CRITICAL (or WARNING) alert is issued if no metric has been posted since the min
 ```
 [plugin.checks.metric-myhost]
 command = ["check-mackerel-metric", "-H", "HOST_ID", "-n", "METRIC_NAME", "-w", "WARNING_MINUTE", "-c", "CRITICAL_MINUTE"]
+
+[plugin.checks.metric-myservice]
+command = ["check-mackerel-metric", "-s", "SERVICE_NAME", "-n", "METRIC_NAME", "-w", "WARNING_MINUTE", "-c", "CRITICAL_MINUTE"]
 ```
 
 ## Usage
 ### Options
-```
--H, --host=     target host ID
--n, --name=     target metric name
--w, --warning=  minute to be WARNING
--c, --critical= minute to be CRITICAL
-```
+- `--host HOST_ID, -H HOST_ID`: target host ID
+- `--service SERVICE_NAME, -s SERVICE_NAME`: target service name
+- `--name METRIC_NAME, -n METRIC_NAME`: target metric name
+- `--warning MINUTE, -w MINUTE`: minute to be WARNING
+- `--critical MINUTE, -c MINUTE`: minute to be CRITICAL
+- `--help, -h`: display the help and exit
 
+- `--host` is for host metrics and `--service` is for service metrics. Choose one of these.
 - HOST_ID is displayed at the top of the Mackerel host screen, like `4Hkc5RWzXXX`.
 - METRIC_NAME can be looked up with `mkr metric-names -H HOST_ID`.
-
+- The API key is taken from the existing mackerel-agent.conf. If you want to use a different API key, you can specify it in the environment variable `MACKEREL_APIKEY`.
 ---
 
 ## 説明
 
-Mackerelのホストメトリックの投稿が継続していることをチェックします。
+Mackerelのホストメトリックあるいはサービスメトリックの投稿が継続していることをチェックします。
 
 クラウドインテグレーションのホストメトリックでも利用可能です。
 
 ## 概要
 ```
 check-mackerel-metric -H HOST_ID -n METRIC_NAME -w WARNING_MINUTE -c CRITICAL_MINUTE
+check-mackerel-metric -s SERVICE_NAME -n METRIC_NAME -w WARNING_MINUTE -c CRITICAL_MINUTE
 ```
 
 現在時刻から CRITICAL_MINUTE (または WARNING_MINUTE) 分前の間に何もメトリックの投稿がないときに、CRITICAL (または WARNING) アラートが発報されます。
@@ -50,16 +56,21 @@ check-mackerel-metric -H HOST_ID -n METRIC_NAME -w WARNING_MINUTE -c CRITICAL_MI
 ```
 [plugin.checks.metric-myhost]
 command = ["check-mackerel-metric", "-H", "HOST_ID", "-n", "METRIC_NAME", "-w", "WARNING_MINUTE", "-c", "CRITICAL_MINUTE"]
+
+[plugin.checks.metric-myservice]
+command = ["check-mackerel-metric", "-s", "SERVICE_NAME", "-n", "METRIC_NAME", "-w", "WARNING_MINUTE", "-c", "CRITICAL_MINUTE"]
 ```
 
 ## 使い方
 ### オプション
-```
--H, --host=     対象のホストID
--n, --name=     対象のメトリック名
--w, --warning=  指定の分数内にメトリックがなければWARNING
--c, --critical= 指定の分数内にメトリックがなければCRITICAL
-```
+- `--host HOST_ID, -H HOST_ID`: 対象のホストID
+- `--service SERVICE_NAME, -s SERVICE_NAME`: 対象のサービス名
+- `--name METRIC_NAME, -n METRIC_NAME`: 対象のメトリック名
+- `--warning MINUTE, -w MINUTE`: 指定の分数内にメトリックがなければWARNING
+- `--critical MINUTE, -c MINUTE`: 指定の分数内にメトリックがなければCRITICAL
+- `--help, -h`: ヘルプの表示と終了
 
+- `--host`はホストメトリック用、`--service`はサービスメトリック用です。どちらか1つを選んでください。
 - HOST_ID (ホストID) はMackerelのホスト画面の上部に `4Hkc5RWzXXX` のように表示されています。
 - METRIC_NAME (メトリック名) は `mkr metric-names -H HOST_ID` で調べることができます。
+- APIキーは既存のmackerel-agent.confから取得されます。別のAPIキーを利用したいときには、環境変数`MACKEREL_APIKEY`で指定できます。

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/mackerelio-labs/check-mackerel-metric
 go 1.21.0
 
 require (
-	github.com/jessevdk/go-flags v1.5.0
 	github.com/mackerelio/checkers v0.0.4
 	github.com/mackerelio/mackerel-agent v0.77.1
 	github.com/mackerelio/mackerel-client-go v0.26.0
@@ -14,6 +13,8 @@ require (
 	github.com/Songmu/timeout v0.4.0 // indirect
 	github.com/Songmu/wrapcommander v0.1.0 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
+	github.com/alexflint/go-arg v1.4.3 // indirect
+	github.com/alexflint/go-scalar v1.1.0 // indirect
 	github.com/mackerelio/golib v1.2.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	golang.org/x/sys v0.9.0 // indirect


### PR DESCRIPTION
無尽蔵に取得されると困るのでparseArgsでc, wをチェックしようとしているが現時点ではうまくいっていない

- flags.ParseArgsの中でエラーがあるとその時点で出力もされてしまう?
- なので、そのあとでさらにチェックという場合、errを返すほかに出力もしないといけない? なんか不吉な匂いがする
- ParseArgsのところで値範囲チェックするような指定ってできないんだろうか。値評価の関数指定はできない?

あとついでに-Hか-Sのどちらかがrequired、みたいな書き方はできなさそうかな…
