### PR TITLE
accept same value for -w and -c to realize critical only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ command = ["check-mackerel-metric", "-s", "SERVICE_NAME", "-n", "METRIC_NAME", "
   - HOST_ID is displayed at the top of the Mackerel host screen, like `4Hkc5RWzXXX`.
   - METRIC_NAME can be looked up with `mkr metric-names -H HOST_ID`.
   - The API key is taken from the existing mackerel-agent.conf. If you want to use a different API key, you can specify it in the environment variable `MACKEREL_APIKEY`.
+  - If `--warning` and `--critical` are set to the same value, only critical alert is enabled.
 
 ## License
 © 2023 Hatena Co., Ltd.
@@ -95,6 +96,7 @@ command = ["check-mackerel-metric", "-s", "SERVICE_NAME", "-n", "METRIC_NAME", "
   - HOST_ID (ホストID) はMackerelのホスト画面の上部に `4Hkc5RWzXXX` のように表示されています。
   - METRIC_NAME (メトリック名) は `mkr metric-names -H HOST_ID` で調べることができます。
   - APIキーは既存のmackerel-agent.confから取得されます。別のAPIキーを利用したいときには、環境変数`MACKEREL_APIKEY`で指定できます。
+  - `--warning` と `--critical` の値を同じ値に設定すると、CRITICALアラートのみが発報されます。
 
 ## ライセンス
 © 2023 Hatena Co., Ltd.

--- a/checkmackerelmetric/checkmackerelmetric.go
+++ b/checkmackerelmetric/checkmackerelmetric.go
@@ -57,8 +57,8 @@ func parseArgs(args []string) (*mackerelMetricOpts, error) {
 	if mo.Host == "" && mo.Service == "" {
 		err = fmt.Errorf("either --host or --service is required")
 	}
-	if mo.Critical <= mo.Warning {
-		err = fmt.Errorf("critical minute must be greater than warning minute")
+	if mo.Critical < mo.Warning {
+		err = fmt.Errorf("critical minute must be equal or greater than warning minute")
 	}
 	return &mo, err
 }

--- a/checkmackerelmetric/checkmackerelmetric_test.go
+++ b/checkmackerelmetric/checkmackerelmetric_test.go
@@ -30,11 +30,11 @@ func TestParseArgs(t *testing.T) {
 	assert.Equal(t, nil, err, "parmeters with max minute should be passed")
 	assert.Equal(t, uint(1441), opts.Critical, "1441 minutes (= max minute) is passed correctly")
 
-	_, err = parseArgs(strings.Split("-H HOSTID -n METRIC -w 1441 -c 60", " "))
-	assert.Equal(t, fmt.Errorf("critical minute must be greater than warning minute"), err, "warning can't over critical")
-
 	_, err = parseArgs(strings.Split("-H HOSTID -n METRIC -w 60 -c 60", " "))
-	assert.Equal(t, fmt.Errorf("critical minute must be greater than warning minute"), err, "warning can't over critical, equal is prohibited")
+	assert.Equal(t, nil, err, "it is acceptable for warning and critical to have the same value")
+
+	_, err = parseArgs(strings.Split("-H HOSTID -n METRIC -w 1441 -c 60", " "))
+	assert.Equal(t, fmt.Errorf("critical minute must be equal or greater than warning minute"), err, "warning can't over critical")
 
 	_, err = parseArgs(strings.Split("-H HOSTID", " "))
 	assert.Equal(t, fmt.Errorf("--name is required"), err, "needs metric name")


### PR DESCRIPTION
ref #23 
This PR try to realize 'critial only mode'.
By this change, --warning and --critical accept same value. It means only Critical is called when there isn't any metric.
