### PR TITLE
set optimize flag

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,6 +14,8 @@ builds:
     goarch:
       - amd64
       - arm64
+    ldflags:
+      - -s -w
 
 archives:
   - format: zip


### PR DESCRIPTION
enable ldflag -s and -w (remove symbols) to reduce the binary size.