### PR TITLE
workaround for Windows path and update README about plugin path

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,37 @@ CRITICAL (or WARNING) alert is issued if no metric has been posted since the min
 
 ## Setting for mackerel-agent
 You can install the plugin by `mkr` command.
+
+##### Linux
 ```
 sudo mkr plugin install check-mackerel-metric
 ```
 
-Add plugin configuration into mackerel-agent.conf.
+##### Windows
+(by Administrator)
 
 ```
+"C:\Program Files\Mackerel\mackerel-agent\mkr.exe" plugin install check-mackerel-metric
+```
+
+Add plugin configuration into mackerel-agent.conf.
+
+##### Linux
+```
 [plugin.checks.metric-myhost]
-command = ["check-mackerel-metric", "-H", "HOST_ID", "-n", "METRIC_NAME", "-w", "WARNING_MINUTE", "-c", "CRITICAL_MINUTE"]
+command = ["/opt/mackerel-agent/plugins/bin/check-mackerel-metric", "-H", "HOST_ID", "-n", "METRIC_NAME", "-w", "WARNING_MINUTE", "-c", "CRITICAL_MINUTE"]
 
 [plugin.checks.metric-myservice]
-command = ["check-mackerel-metric", "-s", "SERVICE_NAME", "-n", "METRIC_NAME", "-w", "WARNING_MINUTE", "-c", "CRITICAL_MINUTE"]
+command = ["/opt/mackerel-agent/plugins/bin/check-mackerel-metric", "-s", "SERVICE_NAME", "-n", "METRIC_NAME", "-w", "WARNING_MINUTE", "-c", "CRITICAL_MINUTE"]
+```
+
+##### Windows
+```
+[plugin.checks.metric-myhost]
+command = ["plugins\\bin\\check-mackerel-metric.exe", "-H", "HOST_ID", "-n", "METRIC_NAME", "-w", "WARNING_MINUTE", "-c", "CRITICAL_MINUTE"]
+
+[plugin.checks.metric-myservice]
+command = ["plugins\\bin\\check-mackerel-metric.exe", "-s", "SERVICE_NAME", "-n", "METRIC_NAME", "-w", "WARNING_MINUTE", "-c", "CRITICAL_MINUTE"]
 ```
 
 ## Usage
@@ -75,18 +94,36 @@ check-mackerel-metric -s SERVICE_NAME -n METRIC_NAME -w WARNING_MINUTE -c CRITIC
 ## mackerel-agentでの設定
 プラグインは `mkr` コマンドでインストールできます。
 
+##### Linux
 ```
 sudo mkr plugin install check-mackerel-metric
 ```
 
-mackerel-agent.conf にプラグインの設定を記述してください。
+##### Windows
+(管理者権限)
 
 ```
+"C:\Program Files\Mackerel\mackerel-agent\mkr.exe" plugin install check-mackerel-metric
+```
+
+mackerel-agent.conf にプラグインの設定を記述してください。
+
+##### Linux
+```
 [plugin.checks.metric-myhost]
-command = ["check-mackerel-metric", "-H", "HOST_ID", "-n", "METRIC_NAME", "-w", "WARNING_MINUTE", "-c", "CRITICAL_MINUTE"]
+command = ["/opt/mackerel-agent/plugins/bin/check-mackerel-metric", "-H", "HOST_ID", "-n", "METRIC_NAME", "-w", "WARNING_MINUTE", "-c", "CRITICAL_MINUTE"]
 
 [plugin.checks.metric-myservice]
-command = ["check-mackerel-metric", "-s", "SERVICE_NAME", "-n", "METRIC_NAME", "-w", "WARNING_MINUTE", "-c", "CRITICAL_MINUTE"]
+command = ["/opt/mackerel-agent/plugins/bin/check-mackerel-metric", "-s", "SERVICE_NAME", "-n", "METRIC_NAME", "-w", "WARNING_MINUTE", "-c", "CRITICAL_MINUTE"]
+```
+
+##### Windows
+```
+[plugin.checks.metric-myhost]
+command = ["plugins\\bin\\check-mackerel-metric.exe", "-H", "HOST_ID", "-n", "METRIC_NAME", "-w", "WARNING_MINUTE", "-c", "CRITICAL_MINUTE"]
+
+[plugin.checks.metric-myservice]
+command = ["plugins\\bin\\check-mackerel-metric.exe", "-s", "SERVICE_NAME", "-n", "METRIC_NAME", "-w", "WARNING_MINUTE", "-c", "CRITICAL_MINUTE"]
 ```
 
 ## 使い方

--- a/checkmackerelmetric/checkmackerelmetric.go
+++ b/checkmackerelmetric/checkmackerelmetric.go
@@ -3,6 +3,8 @@ package checkmackerelmetric
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"runtime"
 	"time"
 
 	"github.com/alexflint/go-arg"
@@ -85,7 +87,17 @@ func (opts *mackerelMetricOpts) run() *checkers.Checker {
 
 	conf, err := config.LoadConfig(config.DefaultConfig.Conffile)
 	if err != nil {
-		return checkers.Unknown(fmt.Sprintf("%v", err))
+		if runtime.GOOS == "windows" {
+			newpath := filepath.Join(config.DefaultConfig.Conffile, "../../../mackerel-agent.conf")
+			conf, err = config.LoadConfig(newpath)
+			if err != nil {
+				return checkers.Unknown(fmt.Sprintf("%v", err))
+			}
+			conf.Conffile = newpath
+			conf.Root = filepath.Dir(newpath)
+		} else {
+			return checkers.Unknown(fmt.Sprintf("%v", err))
+		}
 	}
 	apibase := conf.Apibase
 	if apikey == "" {

--- a/checkmackerelmetric/checkmackerelmetric.go
+++ b/checkmackerelmetric/checkmackerelmetric.go
@@ -91,12 +91,12 @@ func (opts *mackerelMetricOpts) run() *checkers.Checker {
 			newpath := filepath.Join(config.DefaultConfig.Conffile, "../../../mackerel-agent.conf")
 			conf, err = config.LoadConfig(newpath)
 			if err != nil {
-				return checkers.Unknown(fmt.Sprintf("%v", err))
+				return checkers.Unknown(err.Error())
 			}
 			conf.Conffile = newpath
 			conf.Root = filepath.Dir(newpath)
 		} else {
-			return checkers.Unknown(fmt.Sprintf("%v", err))
+			return checkers.Unknown(err.Error())
 		}
 	}
 	apibase := conf.Apibase
@@ -113,7 +113,7 @@ func (opts *mackerelMetricOpts) run() *checkers.Checker {
 
 	client, err := mackerel.NewClientWithOptions(apikey, apibase, false)
 	if err != nil {
-		return checkers.Unknown(fmt.Sprintf("%v", err))
+		return checkers.Unknown(err.Error())
 	}
 
 	return checkMetric(client, opts, criticalFrom, warningFrom, to)
@@ -125,7 +125,7 @@ func checkMetric(client *mackerel.Client, opts *mackerelMetricOpts, criticalFrom
 	// CRITICAL check
 	metricValue, err := fetchMetricValues(client, opts.Host, opts.Service, opts.Metric, criticalFrom, to)
 	if err != nil {
-		return checkers.Unknown(fmt.Sprintf("%v", err))
+		return checkers.Unknown(err.Error())
 	}
 	if len(metricValue) == 0 {
 		return checkers.Critical(fmt.Sprintf("no metric for %s has been posted since at least %d minutes ago", opts.Metric, opts.Critical))


### PR DESCRIPTION
This PR fixes 2 issues.

Update README:
Windows plugin will be installed to C:\Program Files\Mackerel\mackerel-agent\plugins\bin by mkr plugin install.
Linux plugin will be installed to /opt/mackerel-agent/bin.
Users must specify these paths explicitly.

Update handling DefaultConfig.Conffile:
config(from mackerel-agent library).DefaultConfig.Conffile's behaves dfferently in Linux and Windows.
On Linux, it refers to /etc/mackerel-agent.conf, regardless of the location of the plugin.
But on Windows, it mysteriously points to mackerel-agent.conf in the plugin path C:\Program Files\Mackerel\mackerel-agent\plugins\bin\mackerel-agent.conf (yes, this is an invalid location).
 The code I put in run() is awkward, but it acts as a workaround.